### PR TITLE
fix: use `restricted` instead of `private` for access parameter

### DIFF
--- a/build/action.js
+++ b/build/action.js
@@ -5408,6 +5408,26 @@ var normaliseInputBooleanValue = (value) => {
   ].includes(normalised.toLowerCase());
 };
 
+// src/core/command/error.ts
+var ExecutionError = class extends Error {
+  constructor(command) {
+    super([
+      "A command returned a non-zero exit code and therefore is assumed to have failed.",
+      "Please investigate the logs and raise an issue if there seems to be something incorrect."
+    ].join(" "));
+    this.command = command;
+  }
+  toString() {
+    return `
+An execution error occurred whilst executing a command:
+${this.message}
+
+The command in question:
+> ${compose(this.command)}
+    `.trim();
+  }
+};
+
 // src/core/command.ts
 var compose = (command) => {
   var _a;
@@ -5426,24 +5446,6 @@ var execute = async (execute3, command) => {
     return;
   }
   throw new ExecutionError(command);
-};
-var ExecutionError = class extends Error {
-  constructor(command) {
-    super([
-      "A command returned a non-zero exit code and therefore is assumed to have failed.",
-      "Please investigate the logs and raise an issue if there seems to be something incorrect."
-    ].join(" "));
-    this.command = command;
-  }
-  toString() {
-    return `
-An execution error occurred whilst executing a command:
-${this.message}
-
-The command in question:
-> ${compose(this.command)}
-    `.trim();
-  }
 };
 
 // src/core/command/npm.ts
@@ -5494,10 +5496,10 @@ var normaliseInputPublishAccessValue = (value) => {
   switch (value.toLowerCase()) {
     case "public" /* Public */:
       return "public" /* Public */;
-    case "private" /* Private */:
-      return "private" /* Private */;
+    case "restricted" /* Restricted */:
+      return "restricted" /* Restricted */;
     default:
-      throw new Error(`The npm-access tag "${value}" is not valid, must be either "public" or "private"`);
+      throw new Error(`The npm-access tag "${value}" is not valid, must be either "${"public" /* Public */}" or "${"restricted" /* Restricted */}"`);
   }
 };
 var normaliseInputDistributionTagValue = (value) => {

--- a/src/core/action.test.ts
+++ b/src/core/action.test.ts
@@ -150,7 +150,7 @@ describe('action()', (): void => {
     const fail = fn<ActionFailFunction>();
 
     input.mockReturnValueOnce('2.3.4'); // version
-    input.mockReturnValueOnce('private'); // access
+    input.mockReturnValueOnce('restricted'); // access
     input.mockReturnValueOnce(''); // tag
     input.mockReturnValueOnce(''); // dry-run
 
@@ -186,7 +186,7 @@ describe('action()', (): void => {
       2,
       'npm publish',
       [
-        '--access', 'private',
+        '--access', 'restricted',
         '--tag', 'latest',
       ],
       {

--- a/src/core/command/npm.test.ts
+++ b/src/core/command/npm.test.ts
@@ -85,13 +85,13 @@ describe('publish()', (): void => {
     });
   });
 
-  it('with required parameters, with access, private, outputs expected command specification', (): void => {
+  it('with required parameters, with access, restricted, outputs expected command specification', (): void => {
     expect(
-      publish(PublishAccess.Private, 'latest', false),
+      publish(PublishAccess.Restricted, 'latest', false),
     ).toStrictEqual<Command>({
       command: 'npm publish',
       arguments: [
-        '--access', 'private',
+        '--access', 'restricted',
         '--tag', 'latest',
       ],
 

--- a/src/core/command/npm.ts
+++ b/src/core/command/npm.ts
@@ -7,7 +7,7 @@ import type { Command, CommandOptions } from '../command';
  */
 export const enum PublishAccess {
   Public = 'public',
-  Private = 'private',
+  Restricted = 'restricted',
 }
 
 /**

--- a/src/core/command/npm/input.test.ts
+++ b/src/core/command/npm/input.test.ts
@@ -43,7 +43,7 @@ describe('normaliseInputPublishAccessValue()', (): void => {
   it('with invalid string, throw error', (): void => {
     expect(
       () => normaliseInputPublishAccessValue('foobar'),
-    ).toThrowError('The npm-access tag "foobar" is not valid, must be either "public" or "private"');
+    ).toThrowError('The npm-access tag "foobar" is not valid, must be either "public" or "restricted"');
   });
 
   it.each<{ readonly input: string; readonly expected: PublishAccess }>([
@@ -51,9 +51,9 @@ describe('normaliseInputPublishAccessValue()', (): void => {
     { input: 'PUBLIC', expected: PublishAccess.Public },
     { input: 'Public', expected: PublishAccess.Public },
 
-    { input: 'private', expected: PublishAccess.Private },
-    { input: 'PRIVATE', expected: PublishAccess.Private },
-    { input: 'Private', expected: PublishAccess.Private },
+    { input: 'restricted', expected: PublishAccess.Restricted },
+    { input: 'RESTRICTED', expected: PublishAccess.Restricted },
+    { input: 'Restricted', expected: PublishAccess.Restricted },
   ])('with value, $input, returns publish access, $expected', (data): void => {
     expect(
       normaliseInputPublishAccessValue(data.input),

--- a/src/core/command/npm/input.ts
+++ b/src/core/command/npm/input.ts
@@ -41,11 +41,11 @@ export const normaliseInputPublishAccessValue = (value: string): PublishAccess =
     case PublishAccess.Public:
       return PublishAccess.Public;
 
-    case PublishAccess.Private:
-      return PublishAccess.Private;
+    case PublishAccess.Restricted:
+      return PublishAccess.Restricted;
 
     default:
-      throw new Error(`The npm-access tag "${value}" is not valid, must be either "public" or "private"`);
+      throw new Error(`The npm-access tag "${value}" is not valid, must be either "${PublishAccess.Public}" or "${PublishAccess.Restricted}"`);
   }
 };
 


### PR DESCRIPTION
Fixes an issue where private access was using the term `private` but actually (as per the documentation) we need to use `restricted` instead.